### PR TITLE
Fix: Different Approach to ECS IAM Role Access

### DIFF
--- a/main/job_config_inferred.go
+++ b/main/job_config_inferred.go
@@ -135,15 +135,21 @@ type awsCredentialLocal struct {
 // an ECS task definition.
 func loadAWSCredentialWithinECS() (terraformValueObjects.Credential, error) {
 	// Adapted from https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/using-sts.html
-	client := &http.Client{}
-	request, err := http.NewRequest("GET", fmt.Sprintf("169.254.160.2%v", os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")), nil)
+	// curl 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+
+	response, err := http.Get(os.ExpandEnv("169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"))
 	if err != nil {
-		return "", fmt.Errorf("[http.NewRequest][%w]", err)
+		return "", fmt.Errorf("[http.Get][%w]", err)
 	}
-	response, err := client.Do(request)
-	if err != nil {
-		return "", fmt.Errorf("[client.Do][%w]", err)
-	}
+	//client := &http.Client{}
+	//request, err := http.NewRequest("GET", fmt.Sprintf("169.254.160.2%v", os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")), nil)
+	//if err != nil {
+	//	return "", fmt.Errorf("[http.NewRequest][%w]", err)
+	//}
+	//response, err := client.Do(request)
+	//if err != nil {
+	//	return "", fmt.Errorf("[client.Do][%w]", err)
+	//}
 	// TODO: Remove this line once done testing E2E in dev environment prior to push to prod release
 	fmt.Printf("response: %v", response)
 


### PR DESCRIPTION
For managed cloud-concierge instances, the current approach to implementing https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html is not working, so implemented another approach.