### PR TITLE
Increase AWS Log Querier Robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,23 @@ Scalr, Spacelift and Firefly. We find, however, that these tool's pricing can be
 when wanting to self-host runners or access the most desired features like drift detection, security scanning, etc.
 
 ## Quick Start
- [Quick start guide](https://docs.cloudconcierge.io/quick-start).
+### All Cloud Provider Pre-requisites
+0) Obtain an API token at https://app.dragondrop.cloud. We only collect data on when a cloud-concierge starts up (this can be verified here).
+1) Configure an environment variable file (use one of our templates to get started) to control the specifics of cloud-concierge's coverage.
+2) Make sure you have Docker available on your local machine.
+
+### AWS Quickstart
+I) Run aws config on your CLI and ensure that credentials with read-only access to your cloud are configured. If referencing state files stored in an s3 bucket, the credentials specified should be able to read those state files as well.
+
+II) Run the cloud-concierge container using the following command:
+   `
+   docker run --env-file ./my-env-file.env -v main:/main -v ~/.aws:/main/credentials/aws:ro -w /main  dragondropcloud/cloud-concierge:latest
+   `
+
+III) Upon job completion, check the repository against which you configured cloud-concierge to run. There will be a new Pull Request that has been created by Cloud Concierge. [Example Output](https://github.com/dragondrop-cloud/cloud-concierge-example/pull/2).
+
+### Azure & GCP Quickstart
+See more [here](https://docs.cloudconcierge.io/quick-start#gcp).
 
 ## How does it work?
 1) cloud-concierge creates a representation of your cloud infrastructure as Terraform. Only read-only access should be given to cloud-concierge.
@@ -48,9 +64,6 @@ Jobs managed by the [dragondrop platform](https://dragondrop.cloud) log statuses
 can be viewed [here](https://github.com/dragondrop-cloud/cloud-concierge/blob/dev/main/internal/implementations/dragon_drop/http_dragondrop_managed_execution.go) and
 [here](https://github.com/dragondrop-cloud/cloud-concierge/blob/dev/main/internal/implementations/dragon_drop/http_dragondrop_managed_visualization.go).
 
-## Our Roadmap
-We are just getting started, and have a lot of exciting features on our roadmap. More details can be found [here](https://github.com/dragondrop-cloud/cloud-concierge/wiki/Roadmap).
-
 ## Contributing
 Contributions in any form are highly encouraged. Check out our [contributing guide](CONTRIBUTING.md) to get started.
 
@@ -62,11 +75,11 @@ If you are looking to use cloud-concierge at scale, however, the [dragondrop.clo
 - Consolidate multiple cloud-concierge executions into anonymized visualizations of drift, uncodified resources, cloud costs, and security risks.
 - Continue to self-host cloud-concierge instances within your cloud using [serverless infrastructure](https://registry.terraform.io/namespaces/dragondrop-cloud).
 
-## Other Resources
-- [Documentation](https://docs.cloudconcierge.io)
+## Resources
 - [Example Output](https://github.com/dragondrop-cloud/cloud-concierge-example/pull/2)
-- [Schedule Tool Walk Through + Use Case (low stakes and OSS focused!)](https://calendly.com/dragondrop-cloud/cloud-concierge-walk-through)
-- [Terraform Learning Resources](https://dragondrop.cloud/learn/terraform/)
-- [Medium Blog](https://medium.com/@hello_9187)
+- [Documentation](https://docs.cloudconcierge.io)
+- [Roadmap](https://github.com/dragondrop-cloud/cloud-concierge/wiki/Roadmap)
+- [Blog](https://medium.com/@hello_9187)
 - [Slack](https://cloud-concierge.slack.com/join/shared_invite/zt-1xx3sqsb6-cekIXs2whccZvbU81Xn5qg#/shared-invite/email)
+- [Tool Walk Through (low stakes and purely educational)](https://calendly.com/dragondrop-cloud/cloud-concierge-walk-through)
 - [Managed Offering](https://docs.dragondrop.cloud/)

--- a/main/internal/implementations/identify_cloud_actors/log_querier.go
+++ b/main/internal/implementations/identify_cloud_actors/log_querier.go
@@ -58,11 +58,12 @@ func NewLogQuerier(globalConfig Config, provider terraformValueObjects.Provider)
 	}
 }
 
+// TODO: Update unit tests to include the createtags action
 // determineActionClass determines the classification of an input method, which is either a resource
 // "modification", "creation", "deletion", or "not_classified".
 func determineActionClass(value string) string {
 	value = strings.ToLower(value)
-	if strings.Contains(value, "update") || strings.Contains(value, "replace") || strings.Contains(value, "modify") {
+	if strings.Contains(value, "update") || strings.Contains(value, "replace") || strings.Contains(value, "modify") || strings.Contains(value, "createtags") {
 		return "modification"
 	}
 

--- a/main/internal/implementations/identify_cloud_actors/log_querier_test.go
+++ b/main/internal/implementations/identify_cloud_actors/log_querier_test.go
@@ -78,6 +78,11 @@ func TestDetermineActionClass(t *testing.T) {
 		t.Errorf("got:\n%vexpected:\n%v", output, "modification")
 	}
 
+	output = determineActionClass("CreateTags")
+	if output != "modification" {
+		t.Errorf("got:\n%vexpected:\n%v", output, "modification")
+	}
+
 	output = determineActionClass("cloud.run.service.delete")
 	if output != "deletion" {
 		t.Errorf("got:\n%vexpected:\n%v", output, "deletion")

--- a/main/internal/python_scripts/state_of_cloud_report/helpers/new_resources_and_cost_estimation.py
+++ b/main/internal/python_scripts/state_of_cloud_report/helpers/new_resources_and_cost_estimation.py
@@ -252,8 +252,8 @@ def _dataframe_from_cost_estimates_json(
 
     df["is_new_resource"] = df["resource_name"].isin(resource_name_set)
     df.loc[
-        (df["monthly_cost"] == "") | (df["monthly_cost"] == "0"), "monthly_cost"
-    ] = df.loc[(df["monthly_cost"] == "") | (df["monthly_cost"] == "0"), "price"]
+        ((df["monthly_cost"] == "") | (df["monthly_cost"] == "0")) & ~df["is_usage_based"], "monthly_cost"
+    ] = df.loc[((df["monthly_cost"] == "") | (df["monthly_cost"] == "0")) & ~df["is_usage_based"], "price"]
 
     df[["monthly_cost", "monthly_quantity"]] = (
         df[["monthly_cost", "monthly_quantity"]].replace("", 0).astype(float)
@@ -277,11 +277,13 @@ def _calculate_aggregate_costs_across_scan(df: pd.DataFrame) -> pd.DataFrame:
         grouped_tf_status_df.query("is_new_resource == False")
         .rename(columns={"Cost": "Terraform Controlled Resources Monthly Cost"})
         .drop(columns=["is_new_resource"])
+        .reset_index(drop=True)
     )
     grouped_controlled_df = (
         grouped_tf_status_df.query("is_new_resource == True")
         .rename(columns={"Cost": "Uncontrolled Resources Monthly Cost"})
         .drop(columns=["is_new_resource"])
+        .reset_index(drop=True)
     )
 
     combined_cost_summary_df = pd.concat(

--- a/main/internal/python_scripts/state_of_cloud_report/main.py
+++ b/main/internal/python_scripts/state_of_cloud_report/main.py
@@ -70,12 +70,6 @@ def create_markdown_file(job_name: str, markdown_text_output_path):
             resources_to_cloud_actions=resources_to_cloud_actions,
         )
 
-    if cost_estimates:
-        cost_summary_dfs = process_pricing_data(
-            cost_estimates=cost_estimates,
-            new_resources=new_resources,
-        )
-
     markdown_file = MdUtils(
         file_name=f"{markdown_text_output_path}/report.md",
         title=f"{job_name} - State of Scanned Cloud Resources",
@@ -92,25 +86,35 @@ def create_markdown_file(job_name: str, markdown_text_output_path):
 
     markdown_file.new_header(level=1, title="Identified Security Risks", style="atx")
     if security_scan:
-        security_df = security_scan_to_df(list_of_dicts=security_scan["results"])
+        if len(security_scan["results"]) == 0:
+            markdown_file.new_line("No security risks identified within scanned resources.")
+        else:
+            security_df = security_scan_to_df(list_of_dicts=security_scan["results"])
 
-        markdown_file = create_markdown_table_security_scans(
-            markdown_file=markdown_file,
-            security_df=security_df,
-        )
+            markdown_file = create_markdown_table_security_scans(
+                markdown_file=markdown_file,
+                security_df=security_df,
+            )
     else:
-        markdown_file.new_line("Security scan not run.")
+        markdown_file.new_line("No security risks identified within scanned resources.")
 
     markdown_file.new_header(
         level=1, title="Calculable Cloud Costs (Monthly)", style="atx"
     )
     if cost_estimates:
-        markdown_file = create_markdown_table_cost_summary(
-            markdown_file=markdown_file,
-            cost_summary_df=cost_summary_dfs["cost_summary"],
-        )
+        if len(cost_estimates) == 0:
+            markdown_file.new_line("No cost estimates calculated for scanned resources.")
+        else:
+            cost_summary_dfs = process_pricing_data(
+                cost_estimates=cost_estimates,
+                new_resources=new_resources,
+            )
+            markdown_file = create_markdown_table_cost_summary(
+                markdown_file=markdown_file,
+                cost_summary_df=cost_summary_dfs["cost_summary"],
+            )
     else:
-        markdown_file.new_line("Cost estimation not run.")
+        markdown_file.new_line("No cost estimates calculated for scanned resources.")
 
     markdown_file.new_header(
         level=1, title="Resources Outside of Terraform Control", style="atx"
@@ -123,7 +127,7 @@ def create_markdown_file(job_name: str, markdown_text_output_path):
             cost_by_provider_by_type_df=cost_summary_dfs[
                 "uncontrolled_cost_by_div_by_type_df"
             ]
-            if cost_summary_dfs
+            if len(cost_estimates) > 0
             else pd.DataFrame(),
         )
     else:


### PR DESCRIPTION
Resolves #44 and resolves #45, along with some documentation improvements.

Improves cost estimation fidelity in the State of Cloud Report, adds robustness during report execution, and handles edge case in aws log querying that was leading to skipping log values.

Essentially, cloud trail, from which log values are pulled, did not have a resource type assigned for tag updating on at least the `aws_internet_gateway` resource. In our previous implimentation, this was leading to the skipping of relevant cloud events.

Screenshot of this (now correctly handled) edge case in Cloud Trail:
![AWS Event Trail](https://github.com/dragondrop-cloud/cloud-concierge/assets/52042939/73aac417-27b6-4414-a1d0-ec8e1e37deb9)

