### PR TITLE
Change nlp-engine auth endpoint

### DIFF
--- a/main/go.mod
+++ b/main/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Jeffail/gabs/v2 v2.7.0
 	github.com/atsushinee/go-markdown-generator v0.0.0-20191121114853-83f9e1f68504
 	github.com/aws/aws-sdk-go v1.45.1
+	github.com/fatih/color v1.15.0
 	github.com/go-git/go-git/v5 v5.8.1
 	github.com/google/go-github/v45 v45.2.0
 	github.com/hashicorp/hcl/v2 v2.18.0
@@ -34,7 +35,6 @@ require (
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/fatih/color v1.15.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.4.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/main/version_checker.go
+++ b/main/version_checker.go
@@ -14,7 +14,7 @@ import (
 const currentVersion = "v0.1.6"
 const footer = "###########################################################################################################################################################"
 
-// VersionChecker is a struct that contains the http client used to make http requests to github and validate the latest version of cloud-concierge.
+// VersionChecker is a struct that contains the http client used to make http requests to GitHub and validate the latest version of cloud-concierge.
 type VersionChecker struct {
 	// httpClient is a http client shared across all http requests within this package.
 	httpClient http.Client

--- a/nlpengine/main.py
+++ b/nlpengine/main.py
@@ -94,7 +94,7 @@ def authenticate_invocation(token: str):
     url = os.getenv("DRAGONDROP_API_URL")
 
     response = requests.get(
-        url=f"{url}/job/authorize/oss/",
+        url=f"{url}/job/authorize/nlp-engine/",
         headers={
             "Authorization": "Bearer " + token,
             "Content-Type": "application/json",


### PR DESCRIPTION
Updates the endpoint to which the nlp-engine sends a request to the dragondrop API for authentication, with the auth requirements for the previous endpoint having changed.